### PR TITLE
Alternative formulation of orElse and getOrElse

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -47,7 +47,8 @@ export abstract class Option<T> {
   abstract isEmpty(): this is None<T>
   abstract map<U>(f: (value: T) => U): Option<U>
   abstract nonEmpty(): this is Some<T>
-  abstract orElse<U extends T>(alternative: Option<U>): Option<T> | Option<U>
+  abstract or<U extends T>(alternative: Option<U>): Option<T> | Option<U>
+  abstract orElse<U extends T>(alternative: () => Option<U>): Option<T> | Option<U>
   abstract toString(): string
 
   static of<T = {}>(value?: null | undefined): None<T>
@@ -92,9 +93,19 @@ export class None<T> extends Option<T> implements MonadNone<T> {
   }
   nonEmpty(): this is Some<T> & false { return false }
 
-  orElse<U extends T>(alternative: None<U>): None<T>
-  orElse<U extends T>(alternative: Some<U>): Some<U>
-  orElse<U extends T>(alternative: Some<U> | None<U>): None<T> | Some<U> {
+  or<U extends T>(alternative: None<U>): None<T>
+  or<U extends T>(alternative: Some<U>): Some<U>
+  or<U extends T>(alternative: Some<U> | None<U>): None<T> | Some<U> {
+    if (alternative.nonEmpty()) {
+      return alternative
+    }
+    return this
+  }
+
+  orElse<U extends T>(alternative: () => None<U>): None<T>
+  orElse<U extends T>(alternative: () => Some<U>): Some<U>
+  orElse<U extends T>(alternativeFn: () => Some<U> | None<U>): None<T> | Some<U> {
+    const alternative = alternativeFn()
     if (alternative.nonEmpty()) {
       return alternative
     }
@@ -164,9 +175,15 @@ export class Some<T> extends Option<T> implements MonadSome<T> {
     return true
   }
 
-  orElse<U extends T>(alternative: None<U>): Some<T>
-  orElse<U extends T>(alternative: Some<U>): Some<U>
-  orElse<U extends T>(_alternative: Option<U>) {
+  or<U extends T>(alternative: None<U>): Some<T>
+  or<U extends T>(alternative: Some<U>): Some<U>
+  or<U extends T>(_alternative: Option<U>) {
+    return this
+  }
+
+  orElse<U extends T>(alternative: () => None<U>): Some<T>
+  orElse<U extends T>(alternative: () => Some<U>): Some<U>
+  orElse<U extends T>(_alternative: () => Option<U>) {
     return this
   }
 

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,8 @@ export interface MonadSome<T> extends ApplicativeSome<T>, FunctorSome<T>, ChainS
 export abstract class Option<T> {
 
   abstract flatMap<U>(f: (value: T) => Option<U>): Option<U>
-  abstract getOrElse<U extends T>(def: U): T | U
+  abstract getOr<U extends T>(def: U): T | U
+  abstract getOrElse<U extends T>(f: () => U): T | U
   abstract isEmpty(): this is None<T>
   abstract map<U>(f: (value: T) => U): Option<U>
   abstract nonEmpty(): this is Some<T>
@@ -77,8 +78,11 @@ export class None<T> extends Option<T> implements MonadNone<T> {
   flatMap<U>(_f: (value: T) => Option<U>): None<U> {
     return new None<U>()
   }
-  getOrElse<U extends T>(def: U) {
+  getOr<U extends T>(def: U) {
     return def
+  }
+  getOrElse<U extends T>(f: () => U) {
+    return f()
   }
   isEmpty() {
     return true
@@ -134,11 +138,18 @@ export class Some<T> extends Option<T> implements MonadSome<T> {
     return this.value
   }
 
-  getOrElse<U extends T>(def: U): T | U {
+  getOr<U extends T>(def: U): T | U {
     return (
       this.value == null ||
       (typeof this.value === 'number' && isNaN(this.value))
     ) ? def : this.value
+  }
+
+  getOrElse<U extends T>(fn: () => U): T | U {
+    return (
+      this.value == null ||
+      (typeof this.value === 'number' && isNaN(this.value))
+    ) ? fn() : this.value
   }
 
   isEmpty(): this is None<T> & false {

--- a/test.ts
+++ b/test.ts
@@ -7,14 +7,14 @@ test('one', t =>
   t.is(new Some(3)
     .flatMap(() => new Some(5))
     .map(() => 'a')
-    .orElse(new Some('b'))
+    .or(new Some('b'))
     .getOr('c'), 'a'))
 
 test('two', t => t.is(Option.of('a')
   .flatMap(() => new None())
-  .orElse(Option.of('b'))
+  .or(Option.of('b'))
   .map(() => 'c')
-  .orElse(Option.of('d'))
+  .or(Option.of('d'))
   .getOr('e'), 'c'))
 
 test('three', t => {
@@ -30,7 +30,7 @@ test('four', t => {
     return Some.of('a')
   }
   let b: Option<string> = Some.of('b')
-  t.is(Option.of(1).flatMap(a).orElse(b).getOr('c'), 'a')
+  t.is(Option.of(1).flatMap(a).or(b).getOr('c'), 'a')
 })
 
 test('five', t => {
@@ -79,6 +79,18 @@ test('eight (getOrElse with subtype)', t => {
   t.is(foo(Option.of(null).getOrElse(() => arr)), 0)
 })
 
+test('nine', t => {
+  t.plan(3)
+  function foo(x: Option<string>): Option<number> {
+    return x.map(s => s.length)
+  }
+  t.is(foo(Option.of('abcd')).or(Option.of(0)).getOr(1), 4)
+  t.is(foo(Option.of(null)).orElse(() => Option.of(2)).getOr(1), 2)
+  t.throws(() => {
+    Option.of(null).orElse(() => { throw new Error('No value') })
+  }, 'No value')
+})
+
 test('Some#flatMap', t => t.is(Option.of(3).flatMap(_ => Option.of(_ * 2)).get(), 6))
 test('Some#flatMap', t => t.is(Option.of(null).flatMap(() => Option.of(2)).isEmpty(), true))
 
@@ -110,8 +122,8 @@ test('Some#nonEmpty', t => t.is(Option.of(3).nonEmpty(), true))
 test('None#nonEmpty (1)', t => t.is(Option.of(null).nonEmpty(), false))
 test('None#nonEmpty (2)', t => t.is(Option.of(undefined).nonEmpty(), false))
 
-test('Some#orElse', t => t.is(Option.of(2).orElse(Option.of(3)).get(), 2))
-test('None#orElse', t => t.is(Option.of(null).orElse(Option.of(3)).get(), 3))
+test('Some#or', t => t.is(Option.of(2).or(Option.of(3)).get(), 2))
+test('None#or', t => t.is(Option.of(null).or(Option.of(3)).get(), 3))
 
 test('Some#toString', t => t.is(Option.of(3) + '', 'Some(3)'))
 test('None#toString', t => t.is(Option.of(null) + '', 'None'))

--- a/test.ts
+++ b/test.ts
@@ -8,21 +8,21 @@ test('one', t =>
     .flatMap(() => new Some(5))
     .map(() => 'a')
     .orElse(new Some('b'))
-    .getOrElse('c'), 'a'))
+    .getOr('c'), 'a'))
 
 test('two', t => t.is(Option.of('a')
   .flatMap(() => new None())
   .orElse(Option.of('b'))
   .map(() => 'c')
   .orElse(Option.of('d'))
-  .getOrElse('e'), 'c'))
+  .getOr('e'), 'c'))
 
 test('three', t => {
   function foo(bar: any): Option<boolean> {
     return Option.of(Option.of(bar).isEmpty())
   }
   let a = foo('abcd').map(s => s.toString())
-  t.is(a.getOrElse('bad'), 'false')
+  t.is(a.getOr('bad'), 'false')
 })
 
 test('four', t => {
@@ -30,15 +30,53 @@ test('four', t => {
     return Some.of('a')
   }
   let b: Option<string> = Some.of('b')
-  t.is(Option.of(1).flatMap(a).orElse(b).getOrElse('c'), 'a')
+  t.is(Option.of(1).flatMap(a).orElse(b).getOr('c'), 'a')
 })
 
-test('four', t => {
+test('five', t => {
   t.plan(1)
   function foo(x: Option<boolean>) {
-    t.is(x.getOrElse(false).toString(), 'true')
+    t.is(x.getOr(false).toString(), 'true')
   }
   foo(Option.of(true))
+})
+
+test('six', t => {
+  t.plan(3)
+  function foo(x: Option<string>): Option<number> {
+    return x.map(s => s.length)
+  }
+  t.is(foo(Option.of('abcd')).getOr(0), 4)
+  t.is(foo(Option.of(null)).getOrElse(() => 2), 2)
+  t.throws(() => {
+    Option.of(null).getOrElse(() => { throw new Error('No value') })
+  }, 'No value')
+})
+
+interface IFoo {
+  foo?: string
+}
+
+interface IBar extends IFoo {
+  bar?: string
+}
+
+test('seven (getOr with subtype)', t => {
+  t.plan(1)
+  function foo(x: IFoo[]): number {
+      return x.length
+  }
+  const arr: IBar[] = []
+  t.is(foo(Option.of(null).getOr(arr)), 0)
+})
+
+test('eight (getOrElse with subtype)', t => {
+  t.plan(1)
+  function foo(x: IFoo[]): number {
+      return x.length
+  }
+  const arr: IBar[] = []
+  t.is(foo(Option.of(null).getOrElse(() => arr)), 0)
 })
 
 test('Some#flatMap', t => t.is(Option.of(3).flatMap(_ => Option.of(_ * 2)).get(), 6))
@@ -46,19 +84,27 @@ test('Some#flatMap', t => t.is(Option.of(null).flatMap(() => Option.of(2)).isEmp
 
 test('Some#get', t => t.is(Option.of(3).get(), 3))
 
-test('Some#getOrElse', t => t.is(Option.of(1).getOrElse(3), 1))
-test('Some(0)#getOrElse', t => t.is(Option.of(0).getOrElse(12), 0))
-test('Some(false)#getOrElse', t => t.is(Option.of(false).getOrElse(true), false))
-test('Some("")#getOrElse', t => t.is(Option.of('').getOrElse('Hello'), ''))
-test('Some(NaN)#getOrElse', t => t.is(Option.of(NaN).getOrElse(12), 12))
-test('None#getOrElse', t => t.is(Option.of(null).getOrElse(3), 3))
+test('Some#getOr', t => t.is(Option.of(1).getOr(3), 1))
+test('Some(0)#getOr', t => t.is(Option.of(0).getOr(12), 0))
+test('Some(false)#getOr', t => t.is(Option.of(false).getOr(true), false))
+test('Some("")#getOr', t => t.is(Option.of('').getOr('Hello'), ''))
+test('Some(NaN)#getOr', t => t.is(Option.of(NaN).getOr(12), 12))
+test('Some#getOr', t => t.is(Option.of(1).getOr(3), 1))
+test('None#getOr', t => t.is(Option.of(null).getOr(3), 3))
+
+test('Some#getOrElse', t => t.is(Option.of(1).getOrElse(() => 3), 1))
+test('Some(0)#getOrElse', t => t.is(Option.of(0).getOrElse(() => 12), 0))
+test('Some(false)#getOrElse', t => t.is(Option.of(false).getOrElse(() => true), false))
+test('Some("")#getOrElse', t => t.is(Option.of('').getOrElse(() => 'Hello'), ''))
+test('Some(NaN)#getOrElse', t => t.is(Option.of(NaN).getOrElse(() => 12), 12))
+test('None#getOrElse', t => t.is(Option.of(null).getOrElse(() => 3), 3))
 
 test('Some#isEmpty', t => t.is(Option.of(3).isEmpty(), false))
 test('None#isEmpty (1)', t => t.is(Option.of(null).isEmpty(), true))
 test('None#isEmpty (2)', t => t.is(Option.of(undefined).isEmpty(), true))
 
-test('Some#map', t => t.is(Option.of(3).map(() => 4).getOrElse(5), 4))
-test('None#map', t => t.is(Option.of(null).map(() => 4).getOrElse(5), 5))
+test('Some#map', t => t.is(Option.of(3).map(() => 4).getOr(5), 4))
+test('None#map', t => t.is(Option.of(null).map(() => 4).getOr(5), 5))
 
 test('Some#nonEmpty', t => t.is(Option.of(3).nonEmpty(), true))
 test('None#nonEmpty (1)', t => t.is(Option.of(null).nonEmpty(), false))


### PR DESCRIPTION
cc #4 

This renames the current `getOrElse` to `getOr` and adds a new `getOrElse` that takes a function returning a value. In case it helps, this matches [Rust’s `Option.unwrap_or_else`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_else) and [Scala’s `Option.getOrElse`](https://www.scala-lang.org/api/current/scala/Option.html#getOrElse[B%3E:A](default:=%3EB):B). It is, obviously and unfortunately, a breaking change.

If this makes sense, I would like to extend the PR to do the same for the current `orElse`, for consistency: it should be renamed to `or`, and `orElse` should be the version that takes a function returning an `Option`.

(I also fixed the duplicated `four`th test.)